### PR TITLE
User add product #35

### DIFF
--- a/client/components/index.js
+++ b/client/components/index.js
@@ -9,3 +9,4 @@ export { default as Home } from './home';
 export { Login, Signup } from './auth-form';
 export { default as ProductList } from './product-list';
 export { default as Product } from './product';
+export { default as AddProduct } from './product-add';

--- a/client/components/product-add.js
+++ b/client/components/product-add.js
@@ -9,10 +9,11 @@ import {
   fieldEditAddProductDesc,
   fieldEditAddProductImage,
   addNewProductThunk,
+  fieldClearAfterSubmission,
 } from '../store';
 
 export const AddProduct = props => {
-  const nameTaken = props.productNames.includes(props.userInput.name.value);
+  const nameTaken = props.productNames.includes(props.userInput.name);
 
   if (!props.user.id || props.user.isGuest) {
     return <p>You must be a registered user to add a product.</p>;
@@ -27,7 +28,7 @@ export const AddProduct = props => {
             id="addProduct_input_name"
             name="name"
             type="text"
-            value={props.userInput.name.value}
+            value={props.userInput.name}
             onChange={props.handleChange}
             required
           />
@@ -40,8 +41,8 @@ export const AddProduct = props => {
           <input
             id="addProduct_input_price"
             name="price"
-            type="text"
-            value={props.userInput.price.value}
+            type="number"
+            value={props.userInput.price}
             onChange={props.handleChange}
             required
           />
@@ -52,7 +53,7 @@ export const AddProduct = props => {
             id="addProduct_input_desc"
             name="description"
             type="text"
-            value={props.userInput.description.value}
+            value={props.userInput.description}
             onChange={props.handleChange}
             required
           />
@@ -63,7 +64,7 @@ export const AddProduct = props => {
             id="addProduct_input_imageUrl"
             name="imageUrl"
             type="text"
-            value={props.userInput.imageUrl.value}
+            value={props.userInput.imageUrl}
             onChange={props.handleChange}
             required
           />
@@ -88,12 +89,13 @@ const mapDispatchToProps = dispatch => ({
   handleSubmit(event, inputValues, user) {
     event.preventDefault();
     dispatch(addNewProductThunk({
-      name: inputValues.name.value,
-      price: inputValues.price.value,
-      description: inputValues.description.value,
-      imageUrl: inputValues.imageUrl.value,
+      name: inputValues.name,
+      price: inputValues.price,
+      description: inputValues.description,
+      imageUrl: inputValues.imageUrl,
       userId: user.id,
     }));
+    dispatch(fieldClearAfterSubmission());
   },
   handleChange(event) {
     switch (event.target.name) {

--- a/client/components/product-add.js
+++ b/client/components/product-add.js
@@ -12,53 +12,56 @@ import {
 } from '../store';
 
 export const AddProduct = props => {
-  if (!props.user || props.user.isGuest) {
-    return <div>You must be a registered user to add a product.</div>;
+  if (!props.user.id || props.user.isGuest) {
+    return <p>You must be a registered user to add a product.</p>;
   }
   return (
-    <form onSubmit={event => props.handleSubmit(event, props.userInput, props.user)}>
-      <label htmlFor="addProduct_input_name">
-        Product Name
-        <input
-          id="addProduct_input_name"
-          name="name"
-          type="text"
-          value={props.userInput.name.value}
-          onChange={props.handleChange}
-        />
-      </label>
-      <label htmlFor="addProduct_input_price">
-        Product Price
-        <input
-          id="addProduct_input_price"
-          name="price"
-          type="text"
-          value={props.userInput.price.value}
-          onChange={props.handleChange}
-        />
-      </label>
-      <label htmlFor="addProduct_input_desc">
-        Product Description
-        <input
-          id="addProduct_input_desc"
-          name="description"
-          type="text"
-          value={props.userInput.description.value}
-          onChange={props.handleChange}
-        />
-      </label>
-      <label htmlFor="addProduct_input_imageUrl">
-        Product Image URL
-        <input
-          id="addProduct_input_imageUrl"
-          name="imageUrl"
-          type="text"
-          value={props.userInput.imageUrl.value}
-          onChange={props.handleChange}
-        />
-      </label>
-      <button type="submit">Submit</button>
-    </form>
+    <div>
+      <h2>Add Your Product</h2>
+      <form onSubmit={event => props.handleSubmit(event, props.userInput, props.user)}>
+        <label htmlFor="addProduct_input_name">
+          Product Name
+          <input
+            id="addProduct_input_name"
+            name="name"
+            type="text"
+            value={props.userInput.name.value}
+            onChange={props.handleChange}
+          />
+        </label>
+        <label htmlFor="addProduct_input_price">
+          Product Price
+          <input
+            id="addProduct_input_price"
+            name="price"
+            type="text"
+            value={props.userInput.price.value}
+            onChange={props.handleChange}
+          />
+        </label>
+        <label htmlFor="addProduct_input_desc">
+          Product Description
+          <input
+            id="addProduct_input_desc"
+            name="description"
+            type="text"
+            value={props.userInput.description.value}
+            onChange={props.handleChange}
+          />
+        </label>
+        <label htmlFor="addProduct_input_imageUrl">
+          Product Image URL
+          <input
+            id="addProduct_input_imageUrl"
+            name="imageUrl"
+            type="text"
+            value={props.userInput.imageUrl.value}
+            onChange={props.handleChange}
+          />
+        </label>
+        <button type="submit">Submit</button>
+      </form>
+    </div>
   );
 };
 

--- a/client/components/product-add.js
+++ b/client/components/product-add.js
@@ -1,0 +1,101 @@
+/* eslint-disable max-len */
+
+import React from 'react';
+import { connect } from 'react-redux';
+import { withRouter } from 'react-router-dom';
+import {
+  fieldEditAddProductName,
+  fieldEditAddProductPrice,
+  fieldEditAddProductDesc,
+  fieldEditAddProductImage,
+  addNewProductThunk,
+} from '../store';
+
+export const AddProduct = props => {
+  if (!props.user || props.user.isGuest) {
+    return <div>You must be a registered user to add a product.</div>;
+  }
+  return (
+    <form onSubmit={event => props.handleSubmit(event, props.userInput, props.user)}>
+      <label htmlFor="addProduct_input_name">
+        Product Name
+        <input
+          id="addProduct_input_name"
+          name="name"
+          type="text"
+          value={props.userInput.name.value}
+          onChange={props.handleChange}
+        />
+      </label>
+      <label htmlFor="addProduct_input_price">
+        Product Price
+        <input
+          id="addProduct_input_price"
+          name="price"
+          type="text"
+          value={props.userInput.price.value}
+          onChange={props.handleChange}
+        />
+      </label>
+      <label htmlFor="addProduct_input_desc">
+        Product Description
+        <input
+          id="addProduct_input_desc"
+          name="description"
+          type="text"
+          value={props.userInput.description.value}
+          onChange={props.handleChange}
+        />
+      </label>
+      <label htmlFor="addProduct_input_imageUrl">
+        Product Image URL
+        <input
+          id="addProduct_input_imageUrl"
+          name="imageUrl"
+          type="text"
+          value={props.userInput.imageUrl.value}
+          onChange={props.handleChange}
+        />
+      </label>
+      <button type="submit">Submit</button>
+    </form>
+  );
+};
+
+const mapStateToProps = state => ({
+  user: state.user,
+  userInput: state.userInput.addProduct,
+});
+
+const mapDispatchToProps = dispatch => ({
+  handleSubmit(event, inputValues, user) {
+    event.preventDefault();
+    dispatch(addNewProductThunk({
+      name: inputValues.name.value,
+      price: inputValues.price.value,
+      description: inputValues.description.value,
+      imageUrl: inputValues.imageUrl.value,
+      userId: user.id,
+    }));
+  },
+  handleChange(event) {
+    switch (event.target.name) {
+      case 'name':
+        dispatch(fieldEditAddProductName(event.target.value));
+        break;
+      case 'price':
+        dispatch(fieldEditAddProductPrice(event.target.value));
+        break;
+      case 'description':
+        dispatch(fieldEditAddProductDesc(event.target.value));
+        break;
+      case 'imageUrl':
+        dispatch(fieldEditAddProductImage(event.target.value));
+        break;
+      default:
+        break;
+    }
+  },
+});
+
+export default withRouter(connect(mapStateToProps, mapDispatchToProps)(AddProduct));

--- a/client/components/product-add.js
+++ b/client/components/product-add.js
@@ -12,6 +12,8 @@ import {
 } from '../store';
 
 export const AddProduct = props => {
+  const nameTaken = props.productNames.includes(props.userInput.name.value);
+
   if (!props.user.id || props.user.isGuest) {
     return <p>You must be a registered user to add a product.</p>;
   }
@@ -27,7 +29,11 @@ export const AddProduct = props => {
             type="text"
             value={props.userInput.name.value}
             onChange={props.handleChange}
+            required
           />
+          { nameTaken ?
+            <span id="nameTaken">That product name has already been taken - please choose another.</span>
+            : null }
         </label>
         <label htmlFor="addProduct_input_price">
           Product Price
@@ -37,6 +43,7 @@ export const AddProduct = props => {
             type="text"
             value={props.userInput.price.value}
             onChange={props.handleChange}
+            required
           />
         </label>
         <label htmlFor="addProduct_input_desc">
@@ -47,6 +54,7 @@ export const AddProduct = props => {
             type="text"
             value={props.userInput.description.value}
             onChange={props.handleChange}
+            required
           />
         </label>
         <label htmlFor="addProduct_input_imageUrl">
@@ -57,9 +65,14 @@ export const AddProduct = props => {
             type="text"
             value={props.userInput.imageUrl.value}
             onChange={props.handleChange}
+            required
           />
         </label>
-        <button type="submit">Submit</button>
+        <button
+          type="submit"
+          disabled={nameTaken ? 'disabled' : false}
+        >Submit
+        </button>
       </form>
     </div>
   );
@@ -68,6 +81,7 @@ export const AddProduct = props => {
 const mapStateToProps = state => ({
   user: state.user,
   userInput: state.userInput.addProduct,
+  productNames: state.products.map(product => product.name),
 });
 
 const mapDispatchToProps = dispatch => ({

--- a/client/components/product.js
+++ b/client/components/product.js
@@ -50,7 +50,7 @@ export class productComponent extends Component {
 const mapStateToProps = (state, ownProps) => ({
   product: state.products.find(prod => Number(prod.id) === Number(ownProps.match.params.id)),
   user: state.user,
-  cartId: state.user.orders && state.user.orders[state.user.orders.length - 1].status === 'CART' ? state.user.orders[state.user.orders.length - 1].id : 0,
+  cartId: state.user.orders.length && state.user.orders[state.user.orders.length - 1].status === 'CART' ? state.user.orders[state.user.orders.length - 1].id : 0,
 });
 
 const mapDispatchToProps = dispatch => {

--- a/client/components/product.js
+++ b/client/components/product.js
@@ -50,7 +50,7 @@ export class productComponent extends Component {
 const mapStateToProps = (state, ownProps) => ({
   product: state.products.find(prod => Number(prod.id) === Number(ownProps.match.params.id)),
   user: state.user,
-  cartId: state.user.orders.length && state.user.orders[state.user.orders.length - 1].status === 'CART' ? state.user.orders[state.user.orders.length - 1].id : 0,
+  cartId: state.user.orders && state.user.orders[state.user.orders.length - 1].status === 'CART' ? state.user.orders[state.user.orders.length - 1].id : 0,
 });
 
 const mapDispatchToProps = dispatch => {

--- a/client/routes.js
+++ b/client/routes.js
@@ -4,7 +4,7 @@ import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { withRouter, Route, Switch } from 'react-router-dom';
 import PropTypes from 'prop-types';
-import { Login, Signup, Home, UserHome, ProductList, Product } from './components';
+import { Login, Signup, Home, UserHome, ProductList, Product, AddProduct } from './components';
 import { me, fetchAllProducts } from './store';
 
 /**
@@ -25,6 +25,7 @@ class Routes extends Component {
         <Route path="/login" component={Login} />
         <Route path="/signup" component={Signup} />
         <Route exact path="/products" component={ProductList} />
+        <Route exact path="/products/add" component={AddProduct} />
         <Route path="/products/:id" component={Product} />
         {
           isLoggedIn &&

--- a/client/store/index.js
+++ b/client/store/index.js
@@ -3,11 +3,12 @@ import createLogger from 'redux-logger';
 import thunkMiddleware from 'redux-thunk';
 import { composeWithDevTools } from 'redux-devtools-extension';
 import user from './user';
+import userInput from './userInput';
 import products from './products';
 import order_product from './order_product';
 import order from './order';
 
-const reducer = combineReducers({ user, products, order_product, order });
+const reducer = combineReducers({ user, products, order_product, order, userInput });
 const middleware = composeWithDevTools(applyMiddleware(
   thunkMiddleware,
   createLogger({ collapsed: true }),
@@ -16,6 +17,7 @@ const store = createStore(reducer, middleware);
 
 export default store;
 export * from './user';
+export * from './userInput';
 export * from './products';
 export * from './order_product';
 export * from './order';

--- a/client/store/products.js
+++ b/client/store/products.js
@@ -4,6 +4,7 @@ import axios from 'axios';
  * ACTION TYPES
  */
 const GET_ALL_PRODUCTS = 'GET_ALL_PRODUCTS';
+const ADD_NEW_PRODUCT = 'ADD_NEW_PRODUCT';
 
 /**
  * INITIAL STATE
@@ -18,6 +19,11 @@ export const getAllProducts = products => ({
   products,
 });
 
+export const addNewProduct = product => ({
+  type: ADD_NEW_PRODUCT,
+  product,
+});
+
 /**
  * THUNK CREATORS
  */
@@ -29,6 +35,12 @@ export const fetchAllProducts = () =>
         dispatch(getAllProducts(res.data)))
       .catch(err => console.error(err));
 
+export const addNewProductThunk = (product) =>
+  dispatch =>
+    axios.post('/api/products', product)
+      .then(res =>
+        dispatch(addNewProduct(res.data)))
+      .catch(err => console.error(err));
 
 /**
  * REDUCER
@@ -37,6 +49,8 @@ export default function (state = initialState, action) {
   switch (action.type) {
     case GET_ALL_PRODUCTS:
       return action.products;
+    case ADD_NEW_PRODUCT:
+      return [...state, action.product];
     default:
       return state;
   }

--- a/client/store/products.js
+++ b/client/store/products.js
@@ -1,4 +1,5 @@
 import axios from 'axios';
+import history from '../history';
 
 /**
  * ACTION TYPES
@@ -38,8 +39,10 @@ export const fetchAllProducts = () =>
 export const addNewProductThunk = (product) =>
   dispatch =>
     axios.post('/api/products', product)
-      .then(res =>
-        dispatch(addNewProduct(res.data)))
+      .then(res => {
+        dispatch(addNewProduct(res.data));
+        history.push(`/products/${res.data.id}`);
+      })
       .catch(err => console.error(err));
 
 /**

--- a/client/store/userInput.js
+++ b/client/store/userInput.js
@@ -5,28 +5,18 @@ const FIELD_EDIT_ADDPRODUCT_NAME = 'FIELD_EDIT_ADDPRODUCT_NAME';
 const FIELD_EDIT_ADDPRODUCT_PRICE = 'FIELD_EDIT_ADDPRODUCT_PRICE';
 const FIELD_EDIT_ADDPRODUCT_DESC = 'FIELD_EDIT_ADDPRODUCT_DESC';
 const FIELD_EDIT_ADDPRODUCT_IMAGEURL = 'FIELD_EDIT_ADDPRODUCT_IMAGEURL';
+const FIELD_CLEAR_AFTER_SUBMISSION = 'FIELD_CLEAR_AFTER_SUBMISSION';
+
 /**
  * INITIAL STATE
  */
 
 const initialState = {
   addProduct: {
-    name: {
-      value: '',
-      untouched: true,
-    },
-    price: {
-      value: '0',
-      untouched: true,
-    },
-    description: {
-      value: '',
-      untouched: true,
-    },
-    imageUrl: {
-      value: '',
-      untouched: true,
-    },
+    name: '',
+    price: '0',
+    description: '',
+    imageUrl: '',
   },
 };
 /**
@@ -60,6 +50,12 @@ export const fieldEditAddProductImage = function fieldEditAddProductImage(prodIm
     value: prodImageField,
   };
 };
+
+export const fieldClearAfterSubmission = function fieldClearAfterSubmission() {
+  return {
+    type: FIELD_CLEAR_AFTER_SUBMISSION,
+  };
+};
 /**
  * REDUCER
  */
@@ -69,42 +65,33 @@ const reducer = (state = initialState, action) => {
     case FIELD_EDIT_ADDPRODUCT_NAME:
       return Object.assign({}, state, {
         addProduct: Object.assign({}, state.addProduct, {
-          name: {
-            value: action.value,
-            untouched: false,
-          },
+          name: action.value,
         }),
       });
 
     case FIELD_EDIT_ADDPRODUCT_PRICE:
       return Object.assign({}, state, {
         addProduct: Object.assign({}, state.addProduct, {
-          price: {
-            value: action.value,
-            untouched: false,
-          },
+          price: action.value,
         }),
       });
 
     case FIELD_EDIT_ADDPRODUCT_DESC:
       return Object.assign({}, state, {
         addProduct: Object.assign({}, state.addProduct, {
-          description: {
-            value: action.value,
-            untouched: false,
-          },
+          description: action.value,
         }),
       });
 
     case FIELD_EDIT_ADDPRODUCT_IMAGEURL:
       return Object.assign({}, state, {
         addProduct: Object.assign({}, state.addProduct, {
-          imageUrl: {
-            value: action.value,
-            untouched: false,
-          },
+          imageUrl: action.value,
         }),
       });
+
+    case FIELD_CLEAR_AFTER_SUBMISSION:
+      return initialState;
 
     default:
       return state;

--- a/client/store/userInput.js
+++ b/client/store/userInput.js
@@ -1,0 +1,114 @@
+/**
+ * ACTION TYPES
+ */
+const FIELD_EDIT_ADDPRODUCT_NAME = 'FIELD_EDIT_ADDPRODUCT_NAME';
+const FIELD_EDIT_ADDPRODUCT_PRICE = 'FIELD_EDIT_ADDPRODUCT_PRICE';
+const FIELD_EDIT_ADDPRODUCT_DESC = 'FIELD_EDIT_ADDPRODUCT_DESC';
+const FIELD_EDIT_ADDPRODUCT_IMAGEURL = 'FIELD_EDIT_ADDPRODUCT_IMAGEURL';
+/**
+ * INITIAL STATE
+ */
+
+const initialState = {
+  addProduct: {
+    name: {
+      value: '',
+      untouched: true,
+    },
+    price: {
+      value: '0',
+      untouched: true,
+    },
+    description: {
+      value: '',
+      untouched: true,
+    },
+    imageUrl: {
+      value: '',
+      untouched: true,
+    },
+  },
+};
+/**
+ * ACTION CREATORS
+ */
+
+export const fieldEditAddProductName = function fieldEditAddProductName(prodNameField) {
+  return {
+    type: FIELD_EDIT_ADDPRODUCT_NAME,
+    value: prodNameField,
+  };
+};
+
+export const fieldEditAddProductPrice = function fieldEditAddProductPrice(prodPriceField) {
+  return {
+    type: FIELD_EDIT_ADDPRODUCT_PRICE,
+    value: prodPriceField,
+  };
+};
+
+export const fieldEditAddProductDesc = function fieldEditAddProductDesc(prodDescField) {
+  return {
+    type: FIELD_EDIT_ADDPRODUCT_DESC,
+    value: prodDescField,
+  };
+};
+
+export const fieldEditAddProductImage = function fieldEditAddProductImage(prodImageField) {
+  return {
+    type: FIELD_EDIT_ADDPRODUCT_IMAGEURL,
+    value: prodImageField,
+  };
+};
+/**
+ * REDUCER
+ */
+
+const reducer = (state = initialState, action) => {
+  switch (action.type) {
+    case FIELD_EDIT_ADDPRODUCT_NAME:
+      return Object.assign({}, state, {
+        addProduct: Object.assign({}, state.addProduct, {
+          name: {
+            value: action.value,
+            untouched: false,
+          },
+        }),
+      });
+
+    case FIELD_EDIT_ADDPRODUCT_PRICE:
+      return Object.assign({}, state, {
+        addProduct: Object.assign({}, state.addProduct, {
+          price: {
+            value: action.value,
+            untouched: false,
+          },
+        }),
+      });
+
+    case FIELD_EDIT_ADDPRODUCT_DESC:
+      return Object.assign({}, state, {
+        addProduct: Object.assign({}, state.addProduct, {
+          description: {
+            value: action.value,
+            untouched: false,
+          },
+        }),
+      });
+
+    case FIELD_EDIT_ADDPRODUCT_IMAGEURL:
+      return Object.assign({}, state, {
+        addProduct: Object.assign({}, state.addProduct, {
+          imageUrl: {
+            value: action.value,
+            untouched: false,
+          },
+        }),
+      });
+
+    default:
+      return state;
+  }
+};
+
+export default reducer;

--- a/public/style.css
+++ b/public/style.css
@@ -43,3 +43,8 @@ form div {
   color: red;
   justify-content: center;
 }
+
+input::-webkit-inner-spin-button {
+  -webkit-appearance: none;
+  margin: 0; 
+}

--- a/server/api/products.js
+++ b/server/api/products.js
@@ -13,4 +13,10 @@ router.get('/:productId', (req, res, next) => {
     .catch(next);
 });
 
+router.post('/', (req, res, next) => {
+  Product.create(req.body)
+    .then(product => res.status(201).send(product))
+    .catch(next);
+});
+
 module.exports = router;


### PR DESCRIPTION
### Assignee Tasks

- [ ] added unit tests (or none needed)
- [ ] written relevant docs (or none needed)
- [ ] referenced any relevant issues (or none exist)

### Guidelines

Please add a description of this Pull Request's motivation, scope, outstanding issues or potential alternatives, reasoning behind the current solution, and any other relevant information for posterity.

---

*Your PR Notes Here*

This enables the basic functionality of a logged-in user to add their own products via `products/add`.

This involves a new "userInput" sub-reducer which allows for controlled input components. This breaks down each field into its `value` and whether it is `untouched` i.e. "dirty"; the property is not yet referenced/utilized in any code but I found it very useful in my Senior Enrichment Project.

The functionality is definitely bare-bones, and needs some work to prevent users from entering values that will cause database errors, but the size of this commit is already large enough, and touches enough files that we all use (store, routes, etc.) that I'd like to incorporate this into `master` and then work from there.